### PR TITLE
Input element autocomplete attributes

### DIFF
--- a/packages/features/auth/src/components/password-sign-in-form.tsx
+++ b/packages/features/auth/src/components/password-sign-in-form.tsx
@@ -60,6 +60,7 @@ export function PasswordSignInForm({
                   data-test={'email-input'}
                   required
                   type="email"
+                  autoComplete="username"
                   placeholder={t('emailPlaceholder')}
                   {...field}
                 />
@@ -84,6 +85,7 @@ export function PasswordSignInForm({
                   required
                   data-test={'password-input'}
                   type="password"
+                  autoComplete="current-password"
                   placeholder={''}
                   {...field}
                 />

--- a/packages/features/auth/src/components/password-sign-up-form.tsx
+++ b/packages/features/auth/src/components/password-sign-up-form.tsx
@@ -72,6 +72,7 @@ export function PasswordSignUpForm({
                   data-test={'email-input'}
                   required
                   type="email"
+                  autoComplete="username"
                   placeholder={t('emailPlaceholder')}
                   {...field}
                 />
@@ -96,6 +97,7 @@ export function PasswordSignUpForm({
                   required
                   data-test={'password-input'}
                   type="password"
+                  autoComplete="new-password"
                   placeholder={''}
                   {...field}
                 />
@@ -120,6 +122,7 @@ export function PasswordSignUpForm({
                   required
                   data-test={'repeat-password-input'}
                   type="password"
+                  autoComplete="new-password"
                   placeholder={''}
                   {...field}
                 />

--- a/packages/features/auth/src/components/update-password-form.tsx
+++ b/packages/features/auth/src/components/update-password-form.tsx
@@ -72,7 +72,12 @@ export function UpdatePasswordForm(params: { redirectTo: string }) {
                   </FormLabel>
 
                   <FormControl>
-                    <Input required type="password" autoComplete="new-password" {...field} />
+                    <Input
+                      required
+                      type="password"
+                      autoComplete="new-password"
+                      {...field}
+                    />
                   </FormControl>
 
                   <FormMessage />
@@ -89,7 +94,12 @@ export function UpdatePasswordForm(params: { redirectTo: string }) {
                   </FormLabel>
 
                   <FormControl>
-                    <Input required type="password" autoComplete="new-password" {...field} />
+                    <Input
+                      required
+                      type="password"
+                      autoComplete="new-password"
+                      {...field}
+                    />
                   </FormControl>
 
                   <FormMessage />

--- a/packages/features/auth/src/components/update-password-form.tsx
+++ b/packages/features/auth/src/components/update-password-form.tsx
@@ -72,7 +72,7 @@ export function UpdatePasswordForm(params: { redirectTo: string }) {
                   </FormLabel>
 
                   <FormControl>
-                    <Input required type="password" {...field} />
+                    <Input required type="password" autoComplete="new-password" {...field} />
                   </FormControl>
 
                   <FormMessage />
@@ -89,7 +89,7 @@ export function UpdatePasswordForm(params: { redirectTo: string }) {
                   </FormLabel>
 
                   <FormControl>
-                    <Input required type="password" {...field} />
+                    <Input required type="password" autoComplete="new-password" {...field} />
                   </FormControl>
 
                   <FormMessage />


### PR DESCRIPTION
To address the console warning "Input elements should have autocomplete attributes" this pull request adds the attributes to the input fields in the sign-in/sign-up/password-reset component forms.

This improves compatibility with password managers and enhances security by guiding browsers on appropriate autofill behaviour.

## Description of Changes
Added the following;
- `autocomplete="username"` 
- `autocomplete="current-password"` 
- `autocomplete="new-password"`

**Context:**  
Modern browsers require explicit `autocomplete` attributes for password fields to enable secure autofill features and prevent unwanted suggestions. This change resolves a console warning while aligning with WCAG 2.1 accessibility guidelines for input purpose identification.